### PR TITLE
Change time addition logic to JS Date object from Math.round()

### DIFF
--- a/helpers/utilities.ts
+++ b/helpers/utilities.ts
@@ -40,7 +40,8 @@ const Utilities = {
 
 	async generate_token(data: User, generateRefreshToken: Boolean = true): Promise<TokenData> {
 		let refresh_token = null;
-		const expiresAt = (Math.floor(Date.now() / 1000) + 7200);
+		let curr_date=new Date();
+		const expiresAt = (curr_date.setHours(curr_date.getHours()+2));
 		const tokenData = {
 			algorithm: "HS256",
 			issuer: "good-food-tracker",

--- a/helpers/utilities.ts
+++ b/helpers/utilities.ts
@@ -40,8 +40,8 @@ const Utilities = {
 
 	async generate_token(data: User, generateRefreshToken: Boolean = true): Promise<TokenData> {
 		let refresh_token = null;
-		let curr_date=new Date();
-		const expiresAt = (curr_date.setHours(curr_date.getHours()+2));
+		let currentDate=new Date();
+		const expiresAt = (currentDate.setHours(currentDate.getHours()+2));
 		const tokenData = {
 			algorithm: "HS256",
 			issuer: "good-food-tracker",


### PR DESCRIPTION
Fixes #36 .

The following pull request updates the addition of 2 hours logic while generating the `expiresAt` time. It now doesn't use `Math.round()` rather uses functions implemented in JavaScript Date object.