### PR TITLE
[WIP] Feature/docs: Create Swagger UI docs page

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -8,6 +8,8 @@ const path = require('path');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const fileUpload = require("express-fileupload");
+const swaggerJSDoc = require('swagger-jsdoc');
+const swaggerUi = require('swagger-ui-express');
 require('dotenv').config();
 
 const indexRouter = require('./routes/index');
@@ -16,6 +18,38 @@ const profileRoutes = require('./routes/profile');
 const cityRoutes = require('./routes/city');
 const countryRoutes = require('./routes/country');
 const reviewRoutes = require('./routes/review');
+
+const swaggerDefinition = {
+	openapi: '3.0.0',
+	info: {
+		title: 'Good Food Tracker API',
+		version: '0.0.1',
+		description: `The Good Food Tracker project allows users to take
+			pictures and/or leave notes, ratings, and comments about the
+			restaurants they visit for later reference.`,
+		license: {
+			name: 'Licensed Under MIT',
+			url: 'https://spdx.org/licenses/MIT.html',
+		},
+		contact: {
+			name: 'Igor Ilić',
+			email: 'github@igorilic.net',
+		},
+	},
+	servers: [
+		{
+			url: 'http://localhost:3000',
+			description: 'Development server',
+		},
+	],
+};
+
+const options = {
+	swaggerDefinition,
+	apis: ['./routes/*.ts'],
+};
+
+const swaggerSpec = swaggerJSDoc(options);
 
 const app = express();
 
@@ -63,5 +97,6 @@ app.use('/profile', profileRoutes);
 app.use('/city', cityRoutes);
 app.use('/country', countryRoutes);
 app.use('/review', reviewRoutes);
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 module.exports = app;

--- a/app.ts
+++ b/app.ts
@@ -46,7 +46,7 @@ const swaggerDefinition = {
 
 const options = {
 	swaggerDefinition,
-	apis: ['./routes/*.ts'],
+	apis: ['./routes/*.ts', './helpers/typedefs.yml'],
 };
 
 const swaggerSpec = swaggerJSDoc(options);

--- a/helpers/typedefs.yml
+++ b/helpers/typedefs.yml
@@ -4,137 +4,138 @@ tags:
     description: Functions available to all users
   - name: Admin Role
     description: Functions available to admin users only
-definitions:
-  NewCity:
-    type: object
-    properties:
-      name:
-        type: string
-        description: Name of the city
-      countryID:
-        type: integer
-        description: Numeric ID for the country
-    required:
-      - name
-  City:
-    allOf:
-      - type: object
-        properties:
-          cityID:
-            type: integer
-            description: Numeric ID for the city
-          countryName:
-            type: string
-            description: Name of the country
-      - $ref: '#/definitions/NewCity'
-    example:
-      cityID: 0
-      cityName: Berlin
-      countryName: Germany
-      countryID: 4
-  Success:
-    type: object
-    properties:
-      success:
-        type: boolean
-        example: true
-      message:
-        type: string
-        example: ''
-  Error:
-    type: object
-    properties:
-      success:
-        type: boolean
-        example: false
-      message:
-        type: string
-        example: ''
-  InvalidResponse:
-    allOf:
-      - $ref: '#/definitions/Error'
-      - type: object
-        properties:
-          data:
-            type: array
-            items: []
-            example: [null]
-          message:
-            type: string
-            example: ''
-          error:
-            type: object
-            properties:
-              stack:
-                type: string
-                example: ''
-              code:
-                type: integer
-                example: 400
-responses:
-  '200':
-    description: OK
-    content:
-      application/json:
-        schema:
-          $ref: '#/definitions/Success'
-  '400':
-    description: Bad Request
-    content:
-      application/json:
-        schema:
-          allOf:
-            - $ref: '#/definitions/InvalidResponse'
-            - type: object
+components:
+  schemas:
+    NewCity:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the city
+        countryID:
+          type: integer
+          description: Numeric ID for the country
+      required:
+        - name
+    City:
+      allOf:
+        - type: object
+          properties:
+            cityID:
+              type: integer
+              description: Numeric ID for the city
+            countryName:
+              type: string
+              description: Name of the country
+        - $ref: '#/components/schemas/NewCity'
+      example:
+        cityID: 0
+        cityName: Berlin
+        countryName: Germany
+        countryID: 4
+    Success:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        message:
+          type: string
+          example: ''
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: ''
+    InvalidResponse:
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            data:
+              type: array
+              items: []
+              example: [null]
+            message:
+              type: string
+              example: ''
+            error:
+              type: object
               properties:
-                message:
+                stack:
                   type: string
-                  example: invalid city name.
-  '401':
-    description: Unauthorized or Invalid Token
-    content:
-      application/json:
-        schema:
-          allOf:
-            - $ref: '#/definitions/Error'
-            - type: object
-              properties:
-                message:
-                  type: string
-                  example: you are not authorized to perform this action.
-  '404':
-    description: Not Found
-    content:
-      application/json:
-        schema:
-          allOf:
-            - $ref: '#/definitions/InvalidResponse'
-            - type: object
-              properties:
-                error:
-                  type: object
-                  properties:
-                    stack:
-                      type: string
-                      example: ''
-                    code:
-                      type: integer
-                      example: 404
-  '500':
-    description: Internal Server Error
-    content:
-      application/json:
-        schema:
-          allOf:
-            - $ref: '#/definitions/InvalidResponse'
-            - type: object
-              properties:
-                error:
-                  type: object
-                  properties:
-                    stack:
-                      type: string
-                      example: ''
-                    code:
-                      type: integer
-                      example: 500
+                  example: ''
+                code:
+                  type: integer
+                  example: 400
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Success'
+    '400':
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/InvalidResponse'
+              - type: object
+                properties:
+                  message:
+                    type: string
+                    example: invalid city name.
+    '401':
+      description: Unauthorized or Invalid Token
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  message:
+                    type: string
+                    example: you are not authorized to perform this action.
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/InvalidResponse'
+              - type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      stack:
+                        type: string
+                        example: ''
+                      code:
+                        type: integer
+                        example: 404
+    '500':
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/InvalidResponse'
+              - type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      stack:
+                        type: string
+                        example: ''
+                      code:
+                        type: integer
+                        example: 500

--- a/helpers/typedefs.yml
+++ b/helpers/typedefs.yml
@@ -1,0 +1,140 @@
+# Swagger type definitions
+tags:
+  - name: User Role
+    description: Functions available to all users
+  - name: Admin Role
+    description: Functions available to admin users only
+definitions:
+  NewCity:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the city
+      countryID:
+        type: integer
+        description: Numeric ID for the country
+    required:
+      - name
+  City:
+    allOf:
+      - type: object
+        properties:
+          cityID:
+            type: integer
+            description: Numeric ID for the city
+          countryName:
+            type: string
+            description: Name of the country
+      - $ref: '#/definitions/NewCity'
+    example:
+      cityID: 0
+      cityName: Berlin
+      countryName: Germany
+      countryID: 4
+  Success:
+    type: object
+    properties:
+      success:
+        type: boolean
+        example: true
+      message:
+        type: string
+        example: ''
+  Error:
+    type: object
+    properties:
+      success:
+        type: boolean
+        example: false
+      message:
+        type: string
+        example: ''
+  InvalidResponse:
+    allOf:
+      - $ref: '#/definitions/Error'
+      - type: object
+        properties:
+          data:
+            type: array
+            items: []
+            example: [null]
+          message:
+            type: string
+            example: ''
+          error:
+            type: object
+            properties:
+              stack:
+                type: string
+                example: ''
+              code:
+                type: integer
+                example: 400
+responses:
+  '200':
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/Success'
+  '400':
+    description: Bad Request
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: '#/definitions/InvalidResponse'
+            - type: object
+              properties:
+                message:
+                  type: string
+                  example: invalid city name.
+  '401':
+    description: Unauthorized or Invalid Token
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: '#/definitions/Error'
+            - type: object
+              properties:
+                message:
+                  type: string
+                  example: you are not authorized to perform this action.
+  '404':
+    description: Not Found
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: '#/definitions/InvalidResponse'
+            - type: object
+              properties:
+                error:
+                  type: object
+                  properties:
+                    stack:
+                      type: string
+                      example: ''
+                    code:
+                      type: integer
+                      example: 404
+  '500':
+    description: Internal Server Error
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: '#/definitions/InvalidResponse'
+            - type: object
+              properties:
+                error:
+                  type: object
+                  properties:
+                    stack:
+                      type: string
+                      example: ''
+                    code:
+                      type: integer
+                      example: 500

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,44 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
+      "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA=="
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^4.2.3"
+      }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -204,6 +242,14 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -369,6 +415,11 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -480,6 +531,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -681,6 +737,14 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -744,6 +808,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -1138,6 +1212,15 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -1218,6 +1301,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1227,6 +1315,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -1888,6 +1981,11 @@
         "source-map": "^0.6.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "sqlstring": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
@@ -1990,6 +2088,39 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swagger-jsdoc": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-5.0.1.tgz",
+      "integrity": "sha512-Yxrulj5E2dY9HUHjryckFPG66YTwi8pih80pocNacGAojE8J7eN99Cx7NLQx+8sV2C3cnFVbrYVISCLpgmb6aA==",
+      "requires": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "js-yaml": "3.14.0",
+        "swagger-parser": "10.0.2"
+      }
+    },
+    "swagger-parser": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-9jHkHM+QXyLGFLk1DkXBwV+4HyNm0Za3b8/zk/+mjr8jgOSiqm3FOTHBSDsBjtn9scdL+8eWcHdupp2NLM8tDw==",
+      "requires": {
+        "@apidevtools/swagger-parser": "10.0.2"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.36.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.2.tgz",
+      "integrity": "sha512-jbxorhRC/FKk8yMx5zEbg1A1sXc/vsW2vrDTJ3clmaMr9F12zsy161kwnxjVt/vVkMglDOz+BC8ZMY01toxHwA=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.5.tgz",
+      "integrity": "sha512-hs9OqBu2jwmhYyFUhdTiwurvbZC+bq2XnWmmbYymVdwhgJCcGkLdnqymX24ZYUve2nkYSvKPEDCo20ZF+vyw9A==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
       }
     },
     "term-size": {
@@ -2177,6 +2308,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "validator": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
+      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2317,6 +2453,25 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "z-schema": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
+      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^12.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
 		"express": "~4.17.1",
 		"express-fileupload": "^1.2.0",
 		"jsonwebtoken": "^8.5.1",
-		"mysql": "^2.18.1"
+		"mysql": "^2.18.1",
+		"swagger-jsdoc": "^5.0.1",
+		"swagger-ui-express": "^4.1.5"
 	},
 	"devDependencies": {
 		"@types/cookie-parser": "^1.4.2",

--- a/routes/city.ts
+++ b/routes/city.ts
@@ -10,7 +10,7 @@ const validation = require("../helpers/validation");
 const ROLES = require("../helpers/roles");
 const translate = require("../helpers/translation");
 
-router.get("/", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const startLimit: number = req.query.start ? parseInt(req.query.start.toString()) : 0;
 	const endLimit: number = req.query.limit ? parseInt(req.query.limit.toString()) : parseInt(process.env.PER_PAGE || "10");
 
@@ -28,7 +28,7 @@ router.get("/", utilities.authenticateToken(), async (req: Request, res: Respons
 	});
 });
 
-router.get("/:cityID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const city = await cityModel.get(parseInt(req.params["cityID"]));
 
 	if (!city.success) {
@@ -46,7 +46,7 @@ router.get("/:cityID", utilities.authenticateToken(), async (req: Request, res: 
 	});
 });
 
-router.post("/", utilities.authenticateToken(ROLES.Admin),
+router.post("/", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const name = req.body.name;
 
@@ -67,7 +67,7 @@ router.post("/", utilities.authenticateToken(ROLES.Admin),
 		});
 	});
 
-router.patch("/:cityID", utilities.authenticateToken(ROLES.Admin),
+router.patch("/:cityID", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const name = req.body.name;
 		const nameValidation = validation.validate([[name, translate("name"), ["required", {"min_length": 3}]]]);
@@ -93,7 +93,7 @@ router.patch("/:cityID", utilities.authenticateToken(ROLES.Admin),
 		});
 	});
 
-router.delete("/:cityID", utilities.authenticateToken(ROLES.Admin),
+router.delete("/:cityID", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const data = await cityModel.delete(parseInt(req.params["cityID"]));
 

--- a/routes/city.ts
+++ b/routes/city.ts
@@ -34,21 +34,21 @@ const translate = require("../helpers/translation");
  *           application/json:
  *             schema:
  *               allOf:
- *                 - $ref: '#/definitions/Success'
+ *                 - $ref: '#/components/schemas/Success'
  *                 - type: object
  *                   properties:
  *                     data:
  *                       type: array
  *                       items:
- *                         $ref: '#/definitions/City'
+ *                         $ref: '#/components/schemas/City'
  *                     total:
  *                       type: integer
  *                       example: 1
  *       '401':
- *         $ref: '#/responses/401'
+ *         $ref: '#/components/responses/401'
  *       '500':
  *         allOf:
- *           - $ref: '#/responses/500'
+ *           - $ref: '#/components/responses/500'
  *           - content:
  *               application/json:
  *                 schema:
@@ -97,16 +97,16 @@ router.get("/", utilities.authenticate_token(), async (req: Request, res: Respon
  *           application/json:
  *             schema:
  *               allOf:
- *                 - $ref: '#/definitions/Success'
+ *                 - $ref: '#/components/schemas/Success'
  *                 - type: object
  *                   properties:
  *                     data:
- *                       $ref: '#/definitions/City'
+ *                       $ref: '#/components/schemas/City'
  *       '401':
- *         $ref: '#/responses/401'
+ *         $ref: '#/components/responses/401'
  *       '404':
  *         allOf:
- *           - $ref: '#/responses/404'
+ *           - $ref: '#/components/responses/404'
  *           - content:
  *               application/json:
  *                 schema:
@@ -117,7 +117,7 @@ router.get("/", utilities.authenticate_token(), async (req: Request, res: Respon
  *                       example: requested city was not found.
  *       '500':
  *         allOf:
- *           - $ref: '#/responses/500'
+ *           - $ref: '#/components/responses/500'
  *           - content:
  *               application/json:
  *                 schema:
@@ -160,11 +160,11 @@ router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res:
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/definitions/NewCity'
+ *             $ref: '#/components/schemas/NewCity'
  *     responses:
  *       '201':
  *         allOf:
- *           - $ref: '#/responses/200'
+ *           - $ref: '#/components/responses/200'
  *           - description: Created
  *           - content:
  *               application/json:
@@ -175,12 +175,12 @@ router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res:
  *                       type: string
  *                       example: city created successfully.
  *       '400':
- *         $ref: '#/responses/400'
+ *         $ref: '#/components/responses/400'
  *       '401':
- *         $ref: '#/responses/401'
+ *         $ref: '#/components/responses/401'
  *       '500':
  *         allOf:
- *           - $ref: '#/responses/500'
+ *           - $ref: '#/components/responses/500'
  *           - content:
  *               application/json:
  *                 schema:
@@ -231,11 +231,11 @@ router.post("/", utilities.authenticate_token(ROLES.Admin),
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/definitions/NewCity'
+ *             $ref: '#/components/schemas/NewCity'
  *     responses:
  *       '200':
  *         allOf:
- *           - $ref: '#/responses/200'
+ *           - $ref: '#/components/responses/200'
  *           - content:
  *               application/json:
  *                 schema:
@@ -245,12 +245,12 @@ router.post("/", utilities.authenticate_token(ROLES.Admin),
  *                       type: string
  *                       example: city updated successfully.
  *       '400':
- *         $ref: '#/responses/400'
+ *         $ref: '#/components/responses/400'
  *       '401':
- *         $ref: '#/responses/401'
+ *         $ref: '#/components/responses/401'
  *       '500':
  *         allOf:
- *           - $ref: '#/responses/500'
+ *           - $ref: '#/components/responses/500'
  *           - content:
  *               application/json:
  *                 schema:
@@ -303,7 +303,7 @@ router.patch("/:cityID", utilities.authenticate_token(ROLES.Admin),
  *     responses:
  *       '200':
  *         allOf:
- *           - $ref: '#/responses/200'
+ *           - $ref: '#/components/responses/200'
  *           - content:
  *               application/json:
  *                 schema:
@@ -316,10 +316,10 @@ router.patch("/:cityID", utilities.authenticate_token(ROLES.Admin),
  *                       type: string
  *                       example: city deleted successfully.
  *       '401':
- *         $ref: '#/responses/401'
+ *         $ref: '#/components/responses/401'
  *       '500':
  *         allOf:
- *           - $ref: '#/responses/500'
+ *           - $ref: '#/components/responses/500'
  *           - content:
  *               application/json:
  *                 schema:

--- a/routes/city.ts
+++ b/routes/city.ts
@@ -162,9 +162,10 @@ router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res:
  *           schema:
  *             $ref: '#/definitions/NewCity'
  *     responses:
- *       '200':
+ *       '201':
  *         allOf:
  *           - $ref: '#/responses/200'
+ *           - description: Created
  *           - content:
  *               application/json:
  *                 schema:
@@ -173,6 +174,8 @@ router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res:
  *                     message: 
  *                       type: string
  *                       example: city created successfully.
+ *       '400':
+ *         $ref: '#/responses/400'
  *       '401':
  *         $ref: '#/responses/401'
  *       '500':
@@ -222,20 +225,13 @@ router.post("/", utilities.authenticate_token(ROLES.Admin),
  *         in: path
  *         description: Numeric ID of the city to update
  *         required: true
- *       - name: countryID
- *         in: path
- *         description: Numeric ID of the country to update
  *     requestBody:
- *       description: Provide the new name of the city (required)
+ *       description: Provide the new name of the city (required) and the ID of the country (optional)
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               name:
- *                 type: string
- *                 description: New name of the city
+ *             $ref: '#/definitions/NewCity'
  *     responses:
  *       '200':
  *         allOf:

--- a/routes/city.ts
+++ b/routes/city.ts
@@ -12,55 +12,6 @@ const translate = require("../helpers/translation");
 
 /**
  * @swagger
- * tags:
- *   - name: User Role
- *     description: Functions available to all users
- *   - name: Admin Role
- *     description: Functions available to admin users only
- * definitions:
- *   NewCity:
- *     type: object
- *     properties:
- *       name:
- *         type: string
- *         description: Name of the city
- *       countryID:
- *         type: integer
- *         description: Numeric ID for the country
- *     required:
- *       - name
- *   City:
- *     allOf:
- *       - type: object
- *         properties:
- *           cityID:
- *             type: integer
- *             description: Numeric ID for the city
- *           countryName:
- *             type: string
- *             description: Name of the country
- *       - $ref: '#/definitions/NewCity'
- *   Error:
- *     type: object
- *     properties:
- *       success:
- *         type: boolean
- *       data:
- *         type: array
- *         items: []
- *       message:
- *         type: string
- *       error:
- *         type: object
- *         properties:
- *           stack:
- *             type: string
- *           code:
- *             type: integer
- */
-
-/**
- * @swagger
  * /city:
  *   get:
  *     tags:
@@ -82,35 +33,30 @@ const translate = require("../helpers/translation");
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   type: array
- *                   items:
- *                     $ref: '#/definitions/City'
- *                 total:
- *                   type: integer
- *                 message:
- *                   type: string
- *                   example: ''
- *       '401':
- *         description: Unauthorized
- *       '500':
- *         description: Internal Server Error
- *         content:
- *           application/json:
- *             schema:
  *               allOf:
- *                 - $ref: '#/definitions/Error'
- *                 - example:
- *                     success: false
- *                     data: []
- *                     message: 'unable to load cities'
- *                     error:
- *                       stack: ''
- *                       code: 500
+ *                 - $ref: '#/definitions/Success'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/definitions/City'
+ *                     total:
+ *                       type: integer
+ *                       example: 1
+ *       '401':
+ *         $ref: '#/responses/401'
+ *       '500':
+ *         allOf:
+ *           - $ref: '#/responses/500'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: unable to load cities.
 */
 
 router.get("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
@@ -150,33 +96,36 @@ router.get("/", utilities.authenticate_token(), async (req: Request, res: Respon
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   $ref: '#/definitions/City'
- *                 message:
- *                   type: string
- *                   example: ''
- *       '401':
- *         description: Unauthorized
- *       '404':
- *         description: Not Found
- *       '500':
- *         description: Internal Server Error
- *         content:
- *           application/json:
- *             schema:
  *               allOf:
- *                 - $ref: '#/definitions/Error'
- *                 - example:
- *                     success: false
- *                     data: []
- *                     message: 'unable to load city'
- *                     error:
- *                       stack: ''
- *                       code: 500
+ *                 - $ref: '#/definitions/Success'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/definitions/City'
+ *       '401':
+ *         $ref: '#/responses/401'
+ *       '404':
+ *         allOf:
+ *           - $ref: '#/responses/404'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: requested city was not found.
+ *       '500':
+ *         allOf:
+ *           - $ref: '#/responses/500'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: unable to load city.
 */
 
 router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
@@ -214,33 +163,29 @@ router.get("/:cityID", utilities.authenticate_token(), async (req: Request, res:
  *             $ref: '#/definitions/NewCity'
  *     responses:
  *       '200':
- *         description: OK
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 message:
- *                   type: string
- *                   example: 'city created successfully'
+ *         allOf:
+ *           - $ref: '#/responses/200'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message: 
+ *                       type: string
+ *                       example: city created successfully.
  *       '401':
- *         description: Unauthorized
+ *         $ref: '#/responses/401'
  *       '500':
- *         description: Internal Server Error
- *         content:
- *           application/json:
- *             schema:
- *               allOf:
- *                 - $ref: '#/definitions/Error'
- *                 - example:
- *                     success: false
- *                     data: []
- *                     message: 'unable to create city'
- *                     error:
- *                       stack: ''
- *                       code: 500
+ *         allOf:
+ *           - $ref: '#/responses/500'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: unable to create city.
 */
 
 router.post("/", utilities.authenticate_token(ROLES.Admin),
@@ -293,35 +238,31 @@ router.post("/", utilities.authenticate_token(ROLES.Admin),
  *                 description: New name of the city
  *     responses:
  *       '200':
- *         description: OK
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 message:
- *                   type: string
- *                   example: 'city updated successfully'
- *       '401':
- *         description: Unauthorized
+ *         allOf:
+ *           - $ref: '#/responses/200'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: city updated successfully.
  *       '400':
- *         description: Bad Request
+ *         $ref: '#/responses/400'
+ *       '401':
+ *         $ref: '#/responses/401'
  *       '500':
- *         description: Internal Server Error
- *         content:
- *           application/json:
- *             schema:
- *               allOf:
- *                 - $ref: '#/definitions/Error'
- *                 - example:
- *                     success: false
- *                     data: []
- *                     message: 'unable to update city'
- *                     error:
- *                       stack: ''
- *                       code: 500
+ *         allOf:
+ *           - $ref: '#/responses/500'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: unable to update city.
 */
 
 router.patch("/:cityID", utilities.authenticate_token(ROLES.Admin),
@@ -365,36 +306,32 @@ router.patch("/:cityID", utilities.authenticate_token(ROLES.Admin),
  *         required: true
  *     responses:
  *       '200':
- *         description: OK
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   type: array
- *                   items: []
- *                 message:
- *                   type: string
- *                   example: 'city deleted successfully'
+ *         allOf:
+ *           - $ref: '#/responses/200'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items: []
+ *                     message:
+ *                       type: string
+ *                       example: city deleted successfully.
  *       '401':
- *         description: Unauthorized
+ *         $ref: '#/responses/401'
  *       '500':
- *         description: Internal Server Error
- *         content:
- *           application/json:
- *             schema:
- *               allOf:
- *                 - $ref: '#/definitions/Error'
- *                 - example:
- *                     success: false
- *                     data: []
- *                     message: 'unable to delete city'
- *                     error:
- *                       stack: ''
- *                       code: 500
+ *         allOf:
+ *           - $ref: '#/responses/500'
+ *           - content:
+ *               application/json:
+ *                 schema:
+ *                   type: object
+ *                   properties:
+ *                     message:
+ *                       type: string
+ *                       example: unable to delete city.
 */
 
 router.delete("/:cityID", utilities.authenticate_token(ROLES.Admin),

--- a/routes/country.ts
+++ b/routes/country.ts
@@ -9,7 +9,7 @@ const validation = require("../helpers/validation");
 const ROLES = require("../helpers/roles");
 const translate = require("../helpers/translation");
 
-router.get("/", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const startLimit: number = req.query.start ? parseInt(req.query.start.toString()) : 0;
 	const endLimit: number = req.query.limit ? parseInt(req.query.limit.toString()) : parseInt(process.env.PER_PAGE || "10");
 
@@ -27,7 +27,7 @@ router.get("/", utilities.authenticateToken(), async (req: Request, res: Respons
 	});
 });
 
-router.get("/:countryID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/:countryID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const countries = await countryModel.get(parseInt(req.params["countryID"]));
 
 	if (!countries.success) {
@@ -45,7 +45,7 @@ router.get("/:countryID", utilities.authenticateToken(), async (req: Request, re
 	});
 });
 
-router.post("/", utilities.authenticateToken(ROLES.Admin),
+router.post("/", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const name = req.body.name;
 
@@ -66,7 +66,7 @@ router.post("/", utilities.authenticateToken(ROLES.Admin),
 		});
 	});
 
-router.patch("/:countryID", utilities.authenticateToken(ROLES.Admin),
+router.patch("/:countryID", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const {name, code} = req.body;
 		const nameValidation = validation.validate([[name, translate("name"), ["required", {"min_length": 3}]]]);
@@ -92,7 +92,7 @@ router.patch("/:countryID", utilities.authenticateToken(ROLES.Admin),
 		});
 	});
 
-router.delete("/:countryID", utilities.authenticateToken(ROLES.Admin),
+router.delete("/:countryID", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const data = await countryModel.delete(parseInt(req.params["countryID"]));
 

--- a/routes/profile.ts
+++ b/routes/profile.ts
@@ -15,7 +15,7 @@ const fs = require("fs");
 const ROLES = require("../helpers/roles");
 const uploadHelper = require("../helpers/upload");
 
-router.get("/:userID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/:userID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const user = await userModel.get(req.params["userID"] || "");
 
 	if (user.data.length === 0) {
@@ -29,7 +29,7 @@ router.get("/:userID", utilities.authenticateToken(), async (req: Request, res: 
 	});
 });
 
-router.patch("/:userID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.patch("/:userID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const user = Globals.getInstance().user;
 
 	if (!req.user || (req.params["userID"] !== user.guid && user.power < ROLES.Admin)) {
@@ -87,7 +87,7 @@ router.patch("/:userID", utilities.authenticateToken(), async (req: Request, res
 	});
 });
 
-router.delete("/:userID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.delete("/:userID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	if (!req.user || req.user.power < ROLES.Admin && req.params["userID"] !== req["user"]["guid"]) {
 		return res.status(401).send(utilities.invalid_response(translate("not_authorized")));
 	}

--- a/routes/restaurant.ts
+++ b/routes/restaurant.ts
@@ -9,7 +9,7 @@ const validation = require("../helpers/validation");
 const ROLES = require("../helpers/roles");
 const translate = require("../helpers/translation");
 
-router.get("/", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const startLimit: number = req.query.start ? parseInt(req.query.start.toString()) : 0;
 	const endLimit: number = req.query.limit ? parseInt(req.query.limit.toString()) : parseInt(process.env.PER_PAGE || "10");
 	const cityID: number | null = req.query.cityID ? parseInt(req.query.cityID.toString()) : null;
@@ -27,7 +27,7 @@ router.get("/", utilities.authenticateToken(), async (req: Request, res: Respons
 	});
 });
 
-router.get("/:restaurantID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/:restaurantID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const restaurant = await restaurantModel.get(req.params["restaurantID"] || "");
 
 	if (!restaurant.success) {
@@ -45,7 +45,7 @@ router.get("/:restaurantID", utilities.authenticateToken(), async (req: Request,
 	});
 });
 
-router.post("/", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.post("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const name = req.body.name;
 
 	const nameValidation = validation.validate([[name, translate("name"), ["required", {"min_length": 3}]]]);
@@ -65,7 +65,7 @@ router.post("/", utilities.authenticateToken(), async (req: Request, res: Respon
 	});
 });
 
-router.patch("/:restaurantID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.patch("/:restaurantID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const name = req.body.name;
 
 	const nameValidation = validation.validate([[name, translate("name"), ["required", {"min_length": 3}]]]);
@@ -88,7 +88,7 @@ router.patch("/:restaurantID", utilities.authenticateToken(), async (req: Reques
 	});
 });
 
-router.delete("/:restaurantID", utilities.authenticateToken(ROLES.Admin),
+router.delete("/:restaurantID", utilities.authenticate_token(ROLES.Admin),
 	async (req: Request, res: Response, _: NextFunction) => {
 		const data = await restaurantModel.delete(req.params["restaurantID"] || "");
 

--- a/routes/review.ts
+++ b/routes/review.ts
@@ -10,7 +10,7 @@ const validation = require("../helpers/validation");
 const translate = require("../helpers/translation");
 const uploadHelper = require("../helpers/upload");
 
-router.get("/", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const startLimit: number = req.query.start ? parseInt(req.query.start.toString()) : 0;
 	const endLimit: number = req.query.limit ? parseInt(req.query.limit.toString()) : parseInt(process.env.PER_PAGE || "10");
 
@@ -31,7 +31,7 @@ router.get("/", utilities.authenticateToken(), async (req: Request, res: Respons
 	});
 });
 
-router.get("/:reviewID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.get("/:reviewID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const reviewGuid: string = String(req.query.reviewID) || "";
 	const review = await reviewModel.get(reviewGuid);
 
@@ -50,7 +50,7 @@ router.get("/:reviewID", utilities.authenticateToken(), async (req: Request, res
 	});
 });
 
-router.post("/", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.post("/", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const validationResult = validation.validate([
 		[req.body.dish_name, translate("dish_name"), ["required", {"min_length": 3}]],
 	]);
@@ -71,7 +71,7 @@ router.post("/", utilities.authenticateToken(), async (req: Request, res: Respon
 	});
 });
 
-router.patch("/:reviewID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.patch("/:reviewID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const validationResult = validation.validate([
 		[req.body.dish_name, translate("dish_name"), ["required", {"min_length": 3}]],
 		[req.files?.images, translate("uploaded_file"), [{"allowed_file_type": uploadHelper.AllowedExtensions.images}]]
@@ -94,7 +94,7 @@ router.patch("/:reviewID", utilities.authenticateToken(), async (req: Request, r
 	});
 });
 
-router.delete("/:reviewID", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.delete("/:reviewID", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const review = await reviewModel.delete(req.params.reviewID);
 
 	res.status(review.success ? 200 : review.error.code).send({
@@ -103,7 +103,7 @@ router.delete("/:reviewID", utilities.authenticateToken(), async (req: Request, 
 	});
 });
 
-router.delete("/:reviewID/:imageName", utilities.authenticateToken(), async (req: Request, res: Response, _: NextFunction) => {
+router.delete("/:reviewID/:imageName", utilities.authenticate_token(), async (req: Request, res: Response, _: NextFunction) => {
 	const review = await reviewModel.deleteReviewImage(req.params.reviewID, req.params.imageName);
 
 	res.status(review.success ? 200 : review.error.code).send({


### PR DESCRIPTION
This is a basic set of documentation for `routes/city.ts` to demonstrate most of the required fields and how the routes can be organized. The information is pulled from the source code (based on my understanding of it) so let me know if anything is missing or incorrect.

- Navigate to `/docs` to see the Swagger UI page.
- The routes are organized by user role (User, Admin, etc)
- Some object definitions are listed at the top of the `city.ts` file and referenced later using `$ref`.
- There is full information for only one error (500) for now. I'm not sure if this is the best way to present the error codes.
- To update the JSDoc comments, be sure to use 2 spaces for indentation. Tab indentation can't be read by the YAML parser, and I found the lines to be too long and difficult to format with 4-space indentation.

Questions and tasks:

- All servers need to be added to the `definitionObject` in `app.ts`. You could also add more contact info. See the [specification](https://swagger.io/specification/).
- `city.update`: Is the `countryID` parameter a path or query parameter?
- Code examples in various languages (e.g., cURL, JavaScript) still need to be added, if you want them.
- The success and error messages are copied manually from `languages/english.json`. I'm not sure if there's a way to avoid this duplication. Any ideas?
- Refactoring: More definitions can be created when all the information is in place.
- Other route files can be documented when this one is complete.

I hope this provides us with a good starting point. Let me know if you have any questions. :)