### PR TITLE
Add jetbrains/phpstorm-attributes as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "predis/predis": "^1.1"
   },
   "require-dev": {
-    "zircote/swagger-php": "^3.0"
+    "zircote/swagger-php": "^3.0",
+    "jetbrains/phpstorm-attributes": "^1.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73dcf778baff4fa650b7cb9714786222",
+    "content-hash": "a11f2b9f163a2f5b63b1090346a88f9a",
     "packages": [
         {
             "name": "brick/math",
@@ -1192,6 +1192,48 @@
                 }
             ],
             "time": "2020-05-25T17:44:05+00:00"
+        },
+        {
+            "name": "jetbrains/phpstorm-attributes",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JetBrains/phpstorm-attributes.git",
+                "reference": "a7a83ae5df4dd3c0875484483de19de8edf60a9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-attributes/zipball/a7a83ae5df4dd3c0875484483de19de8edf60a9f",
+                "reference": "a7a83ae5df4dd3c0875484483de19de8edf60a9f",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JetBrains\\PhpStorm\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "JetBrains",
+                    "homepage": "https://www.jetbrains.com"
+                }
+            ],
+            "description": "PhpStorm specific attributes",
+            "keywords": [
+                "attributes",
+                "jetbrains",
+                "phpstorm"
+            ],
+            "support": {
+                "issues": "https://youtrack.jetbrains.com/newIssue?project=WI",
+                "source": "https://github.com/JetBrains/phpstorm-attributes/tree/1.0"
+            },
+            "time": "2020-11-17T11:09:47+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Fixes DeepSource issue PHP-W1022 & PHP-W1031.

`JetBrains\PhpStorm\Pure` attribute class is part of phpstorm-stubs package so in order to find that class `jetbrains/phpstorm-attributes` dependency needs to be present in `composer.json` file.